### PR TITLE
Allow export path to be set as a command line argument

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,7 +23,9 @@ var gutil = require('gulp-util'),
 
     changedHelpers = require('./lib/gulp-changed-helpers'),
     root = path.join(__dirname),
-    crateCssOut = 'crate.min.css';
+    crateCssOut = 'crate.min.css',
+    
+    argv = require("minimist")(process.argv.slice(2));
 
 var isDebugging,
     debugPipe,
@@ -48,7 +50,7 @@ var options = _.defaults(locals, options);
 
 isDebugging = options.isDebugging;
 isProduction = options.isProduction;
-exportPath = options.exportPath || paths.export;
+exportPath = argv["export-path"] || options.exportPath || paths.export;
 
 var autoprefix = new LessAutoprefixer({
     browsers: options.browserList

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "lazypipe": "^1.0.1",
     "less-plugin-autoprefix": "^1.5.1",
     "lodash-node": "^3.10.1",
+    "minimist": "^1.2.0",
     "swig": "^1.4.2",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.12.1"


### PR DESCRIPTION
This makes it easier to automate the export of the pattern library.

If you have alternative suggestions on how to accomplish the same thing, then that's fine by me. I'd just like a way to be able to set the export path without having to edit files on disk, so that this can be automated in a script.
