### PR TITLE
Fix editor styles in planner lesson plans

### DIFF
--- a/blocks/core/ff_module/ff_module-planner-note/ff_module-planner-note.xsl
+++ b/blocks/core/ff_module/ff_module-planner-note/ff_module-planner-note.xsl
@@ -23,7 +23,7 @@
         <div data-ff="editor-inline-toolbar"></div>
         <div data-ff="editor-inline-content">
             <xsl:attribute name="class">
-                <xsl:text>ff_util-prose ff_module-planner-note__content</xsl:text>
+                <xsl:text>ff_module-planner-note__content</xsl:text>
                 <xsl:if test="not($has-a-note = 'true')"> ff_module-planner-note__content--empty</xsl:if>
             </xsl:attribute>
             <xsl:value-of select="$data/event/note" disable-output-escaping="yes"/>


### PR DESCRIPTION
The `ff_util-prose` class was interfering with the editor styles, so I've removed it. This is probably a bit drastic, but I wasn't sure how we want to handle the interaction between these styles. Feel free to accomplish the same thing with something less hacktastic!
