### PR TITLE
Allow some containers to be used as templates

### DIFF
--- a/blocks/core/ff_container/ff_container-page-header/ff_container-page-header.xml
+++ b/blocks/core/ff_container/ff_container-page-header/ff_container-page-header.xml
@@ -1,3 +1,3 @@
-<page-header title="Whatever">
+<page-header title="Page title">
     <controls title="Whut"/>
 </page-header>

--- a/blocks/core/ff_container/ff_container-page-header/ff_container-page-header.xsl
+++ b/blocks/core/ff_container/ff_container-page-header/ff_container-page-header.xsl
@@ -2,10 +2,12 @@
 	<xsl:param name="data" />
     
     <div class="ff_container-page-header">
-        <h1 class="ff_container-page-header__title">Page Title</h1>
-        <div class="ff_container-page-header__controls">
-            <div class="crate_util-block">Steps, or whatever</div>
-        </div>
+        <h1 class="ff_container-page-header__title"><xsl:value-of select="$data/page-header/@title"/></h1>
+        <xsl:if test="$data/page-header/controls">
+            <div class="ff_container-page-header__controls">
+                <div class="crate_util-block">Steps, or whatever</div>
+            </div>
+        </xsl:if>
     </div>
 
 </xsl:template>

--- a/blocks/core/ff_container/ff_container-page/ff_container-page.xml
+++ b/blocks/core/ff_container/ff_container-page/ff_container-page.xml
@@ -1,1 +1,3 @@
-<page/>
+<content>
+    <span class="crate_util-block">Page Content</span>
+</content>

--- a/blocks/core/ff_container/ff_container-page/ff_container-page.xsl
+++ b/blocks/core/ff_container/ff_container-page/ff_container-page.xsl
@@ -2,7 +2,7 @@
 	<xsl:param name="data" />
     
     <div class="ff_container-page">
-        <span class="crate_util-block">Page Content</span>
+        <xsl:copy-of select="$data/content/*"/>
     </div>
 
 </xsl:template>

--- a/blocks/core/ff_container/ff_container-tabs-content/ff_container-tabs-content.md
+++ b/blocks/core/ff_container/ff_container-tabs-content/ff_container-tabs-content.md
@@ -3,19 +3,23 @@ data:
     tabs:
       -
         active: true
-        content: "Overview Tab"
+        label: "Overview"
+        content: "<p>Overview Tab</p>"
         id: "tab1a"
       -
         active: false
-        content: "Details Tab"
+        label: "Details"
+        content: "<p>Details Tab</p>"
         id: "tab2a"
       -
         active: false
-        content: "Tasks Tab"
+        label: "Tasks"
+        content: "<p>Tasks Tab</p>"
         id: "tab3a"
       -
         active: false
-        content: "Students Tab"
+        label: "Students"
+        content: "<p>Students Tab</p>"
         id: "tab4a"
 ---
 

--- a/blocks/core/ff_container/ff_container-tabs-content/ff_container-tabs-content.xml
+++ b/blocks/core/ff_container/ff_container-tabs-content/ff_container-tabs-content.xml
@@ -1,7 +1,8 @@
 <tabs modifier="{{modifier}}">
     {% for tab in tabs %}
         <tab active="{{tab.active | default('false')}}" id="{{tab.id}}">
-            <content>{{tab.content | default('Tab Content')}}</content>
+            <label>{{tab.label}}</label>
+            <content>{{tab.content | default('<p>Tab Content</p>') | safe}}</content>
         </tab>
     {% endfor %}
 </tabs>

--- a/blocks/core/ff_container/ff_container-tabs-content/ff_container-tabs-content.xsl
+++ b/blocks/core/ff_container/ff_container-tabs-content/ff_container-tabs-content.xsl
@@ -18,7 +18,7 @@
             <xsl:attribute name="id">
                 <xsl:value-of select="@id" />
             </xsl:attribute>
-            <span class="crate_util-block"><xsl:value-of select="content" /></span>
+            <xsl:copy-of select="content/*"/>
         </div>
     </xsl:for-each>
 

--- a/blocks/core/lib_test/lib_test-tabs/lib_test-tabs.md
+++ b/blocks/core/lib_test/lib_test-tabs/lib_test-tabs.md
@@ -4,23 +4,23 @@ data:
     tabs:
       -
         active: true
-        label: Overview
-        content: "Overview Tab"
+        label: "Overview"
+        content: "<p>Overview Tab</p>"
         id: "tab1"
       -
         active: false
         label: Details
-        content: "Details Tab"
+        content: "<p>Details Tab</p>"
         id: "tab2"
       -
         active: false
         label: Tasks
-        content: "Tasks Tab"
+        content: "<p>Tasks Tab</p>"
         id: "tab3"
       -
         active: false
         label: Students
-        content: "Students Tab"
+        content: "<p>Students Tab</p>"
         id: "tab4"
 requires:   
     - ff_module-tabs-navigation

--- a/blocks/core/lib_test/lib_test-tabs/lib_test-tabs.xml
+++ b/blocks/core/lib_test/lib_test-tabs/lib_test-tabs.xml
@@ -2,7 +2,7 @@
     {% for tab in tabs %}
         <tab active="{{tab.active | default('false')}}" id="{{tab.id}}">
             <label>{{tab.label | default('Tab Label')}}</label>
-            <content>{{tab.content | default('Tab Content')}}</content>
+            <content>{{tab.content | default('<p>Tab Content</p>') | safe}}</content>
         </tab>
     {% endfor %}
 </tabs>


### PR DESCRIPTION
This tweaks some of the containers so that they can be used as containers from Firefly.

@roobottom I think you mentioned that containers were meant to be copy and pasted instead of used as templates. Is there a reason why tweaking them as in this pull request is a bad idea?
