### PR TITLE
Changes for class details page

### DIFF
--- a/blocks/core/ff_container/ff_container-item-repeater/ff_container-item-repeater.xsl
+++ b/blocks/core/ff_container/ff_container-item-repeater/ff_container-item-repeater.xsl
@@ -5,7 +5,7 @@
 		<ol class="ff_container-item-repeater__items">
 			<xsl:for-each select="$data/items/item">
 				<li class="ff_container-item-repeater__item">
-					<xsl:value-of select="."/>
+					<xsl:copy-of select="node()"/>
 				</li>
 			</xsl:for-each>
 		</ol>

--- a/blocks/core/ff_container/ff_container-page/ff_container-page.xsl
+++ b/blocks/core/ff_container/ff_container-page/ff_container-page.xsl
@@ -2,7 +2,7 @@
 	<xsl:param name="data" />
     
     <div class="ff_container-page">
-        <xsl:copy-of select="$data/content/*"/>
+        <xsl:copy-of select="$data/content/node()"/>
     </div>
 
 </xsl:template>

--- a/blocks/core/ff_container/ff_container-tabs-content/ff_container-tabs-content.xsl
+++ b/blocks/core/ff_container/ff_container-tabs-content/ff_container-tabs-content.xsl
@@ -18,7 +18,7 @@
             <xsl:attribute name="id">
                 <xsl:value-of select="@id" />
             </xsl:attribute>
-            <xsl:copy-of select="content/*"/>
+            <xsl:copy-of select="content/node()"/>
         </div>
     </xsl:for-each>
 

--- a/blocks/core/ff_grid/ff_grid.xml
+++ b/blocks/core/ff_grid/ff_grid.xml
@@ -1,5 +1,7 @@
 <grid modifier="{{ modifiers }}">
     {% for column in columns %}
-        <column name="{{ column.name }}"/>
+        <column>
+            <span class="crate_util-block">{{ column.name }}</span>
+        </column>
     {% endfor %}
 </grid>

--- a/blocks/core/ff_grid/ff_grid.xsl
+++ b/blocks/core/ff_grid/ff_grid.xsl
@@ -4,7 +4,9 @@
 
     <div class="ff_grid {$data/grid/@modifier}">
         <xsl:for-each select="$data/grid/column">
-            <div class="ff_grid__column"><span class="crate_util-block"><xsl:value-of select="@name"/></span></div>
+            <div class="ff_grid__column">
+                <xsl:copy-of select="node()"/>
+            </div>
         </xsl:for-each>
     </div>
         

--- a/blocks/core/ff_module/ff_module-task/ff_module-task.less
+++ b/blocks/core/ff_module/ff_module-task/ff_module-task.less
@@ -21,7 +21,18 @@
     }
     .ff_module-task__item--progress {
         width: 28%;
-    } 
+    }
+    
+    .ff_module-task--stacked {
+        display: block;
+        
+        .ff_module-task__item--title,
+        .ff_module-task__item--to, 
+        .ff_module-task__item--date,
+        .ff_module-task__item--progress {
+            width: auto;
+        }
+    }
 }
 
 

--- a/blocks/core/ff_module/ff_module-task/ff_module-task.md
+++ b/blocks/core/ff_module/ff_module-task/ff_module-task.md
@@ -1,6 +1,7 @@
 ---
 data:
   -
+    modifier: stacked
     id: "100"
     message: "Read pages 45-58 of your history coursework books, we'll discuss in class."
     link_href: "#"

--- a/blocks/core/ff_module/ff_module-task/ff_module-task.xsl
+++ b/blocks/core/ff_module/ff_module-task/ff_module-task.xsl
@@ -6,10 +6,18 @@
     </xsl:variable>
     <xsl:variable name="progress-bar" select="ext:node-set($nodes)" />
     
-    <dl class="ff_module-task">
+    <dl>
+        <xsl:attribute name="class">
+            <xsl:text>ff_module-task</xsl:text>
+            <xsl:if test="$data/notice/@modifier">
+                <xsl:text> ff_module-task--</xsl:text><xsl:value-of select="$data/notice/@modifier"/>
+            </xsl:if>
+        </xsl:attribute>
         <dt class="ff_module-task__item ff_module-task__item--title">
             <a href="{$data/notice/@href}" class="ff_module-task__link"><xsl:value-of select="$data/notice/htmlMessage"/></a>
-            <span class="ff_module-task__meta">Set by <xsl:value-of select="$data/notice/@from"/></span>
+            <xsl:if test="$data/notice/@from">
+                <span class="ff_module-task__meta">Set by <xsl:value-of select="$data/notice/@from"/></span>
+            </xsl:if>
         </dt>
         <dd class="ff_module-task__item ff_module-task__item--to"><xsl:value-of select="$data/notice/@to"/></dd>
         <dd class="ff_module-task__item ff_module-task__item--date"><xsl:if test="not($data/notice/@duedate = '')">Due </xsl:if><time><xsl:value-of select="$data/notice/@duedate"/></time></dd>


### PR DESCRIPTION
This tweaks some more container templates, and also adds a `stacked` modifier for `ff_module-task`. I've assumed that the modifier should just affect whether its stacked or side-by-side rather than what information is displayed. I wasn't entirely sure what HTML we wanted when information was missing -- presumably we want to keep the empty elements so that alignment is preserved? Another option is to get rid of those elements if they're empty and the `stacked` modifier is set.

The other thing I'm not sure about is whether we need to somehow put the due date in the same element as the message -- at the moment, there's a bit of vertical spacing between the message and the due date that isn't present in the design.
