### PR TITLE
Fixing premature update of results and query state

### DIFF
--- a/blocks/core/ff_module/ff_module-recipient-picker/ff_module-recipient-picker-component/_ff_module-recipient-picker-component-viewcontrol.js
+++ b/blocks/core/ff_module/ff_module-recipient-picker/ff_module-recipient-picker-component/_ff_module-recipient-picker-component-viewcontrol.js
@@ -137,12 +137,16 @@ module.exports = function createRecipientPicker(service, template) {
                 hasQuery;
 
             hasQuery = /\S+/.test(query);
-            this.setState({
-                hasQuery: hasQuery,
-                isActive: hasQuery
-            });
+            var resultsFn = function(results) {
+                this.setResults(results);
+                this.setState({
+                    hasQuery: hasQuery,
+                    isActive: hasQuery
+                });
+            }.bind(this);
 
-            service.getSearchResults(query, this.setResults);
+
+            service.getSearchResults(query, resultsFn);
         }
     });
 


### PR DESCRIPTION
Updating recipient picker to prevent premature setting of state to prevent 'No results' message firing before results returned @mwilliamson-firefly
