### PR TITLE
Display none on validation message

### DIFF
--- a/blocks/melody/_shared/bett2016.less
+++ b/blocks/melody/_shared/bett2016.less
@@ -1,5 +1,6 @@
 // FIXME: Remove and create own pattern after BETT
 .ff-no-recipients-message {
+    display: none;
     margin-top: 50px;
     padding: .75rem 1rem;
     background-color: lighten(@ff_colour_red, 30%);


### PR DESCRIPTION
Stops the page from adjusting when the message is immediately removed from the dom after loading the page
