### PR TITLE
removed vertical margins. Fixed modifiers on test page

### DIFF
--- a/blocks/core/ff_grid/ff_grid.less
+++ b/blocks/core/ff_grid/ff_grid.less
@@ -1,5 +1,4 @@
 @ff_grid-gap-horizonal: 3%;
-@ff_grid-gap-vertical: @ff_size_spacing_max;
 
 //2col
 @ff_grid-2col-base: 100% - @ff_grid-gap-horizonal;
@@ -21,7 +20,6 @@
   width: 100%;
   clear: left;
   box-sizing: border-box;
-  margin-bottom: 10px;
 }
 
 @media (min-width: @ff_bp_wide) {
@@ -31,7 +29,6 @@
     .ff_grid--1-2 .ff_grid__column {
       width: @ff_grid-2col-equal;
       float: left;
-      margin: @ff_grid-gap-vertical 0;
       &:nth-of-type(2n-1) {
           margin-right: @ff_grid-gap-horizonal;
       }

--- a/pages/tests/grids.md
+++ b/pages/tests/grids.md
@@ -4,26 +4,26 @@ page:
     layout: list-blocks
 data:
   - ff_grid:
-    - 
-      modifiers: "ff_grid--2-1"
+    -
+      modifiers: "2-1"
       columns:
-        - 
+        -
           name: "Wide Column"
-        - 
+        -
           name: "Narrow Column"
     -
-      modifiers: "ff_grid--1-2"
+      modifiers: "1-2"
       columns:
-        - 
+        -
           name: "Narrow Column"
-        - 
+        -
           name: "Wide Column"
     -
-      modifiers: "ff_grid--1-1"
+      modifiers: "1-1"
       columns:
-        - 
+        -
           name: "Equal Column"
-        - 
+        -
           name: "Equal Column"
-    
+
 ---


### PR DESCRIPTION
This removes the vertical margins on grids. I'm of the opinion that grids shouldn't have anything to say about vertical spacing, this should be left to the `ff_util-row-*` classes.
