### PR TITLE
Fix Object definitions in task event javascript

### DIFF
--- a/blocks/core/ff_module/ff_module-task-event-editor/ff_module-task-event-editor.js
+++ b/blocks/core/ff_module/ff_module-task-event-editor/ff_module-task-event-editor.js
@@ -13,7 +13,6 @@ module.exports = React.createClass({
     displayName: 'TaskEventEditor',
     render: function() {
         var eventEditor = eventEditorComponents[this.props.event.type](this.props);
-
         return React.createElement(EditorBase, {
                 title: eventEditor.title,
                 sendText: eventEditor.sendText,
@@ -76,30 +75,31 @@ function markAndGrade(props) {
     };
 }
 
-var eventEditorComponents = {
-    [eventTypes.stampResponseAsSeen]: createEventWithMessageEditor({
-        title: "Stamp as Seen",
-        messageLabel: "Feedback (optional)",
-        sendText: "Send Stamp"
-    }),
-    [eventTypes.requestResubmission]: createEventWithMessageEditor({
-        title: "Request Resubmission",
-        messageLabel: "Reason for Request (optional)",
-        sendText: "Send Request"
-    }),
-    [eventTypes.confirmTaskIsComplete]: createEventWithMessageEditor({
-        title: "Confirm Task is Complete",
-        messageLabel: "Feedback (optional)",
-        sendText: "Send Confirmation"
-    }),
-    [eventTypes.confirmStudentIsExcused]: createEventWithMessageEditor({
-        title: "Confirm Student is Excused",
-        messageLabel: "Comment (optional)",
-        sendText: "Send Confirmation"
-    }),
-    [eventTypes.comment]: createEventWithMessageEditor({
-        title: "Comment",
-        sendText: "Add Comment"
-    }),
-    [eventTypes.markAndGrade]: markAndGrade
-};
+var eventEditorComponents = {};
+
+eventEditorComponents[eventTypes.stampResponseAsSeen] = createEventWithMessageEditor({
+    title: "Stamp as Seen",
+    messageLabel: "Feedback (optional)",
+    sendText: "Send Stamp"
+});
+eventEditorComponents[eventTypes.requestResubmission] = createEventWithMessageEditor({
+    title: "Request Resubmission",
+    messageLabel: "Reason for Request (optional)",
+    sendText: "Send Request"
+});
+eventEditorComponents[eventTypes.confirmTaskIsComplete] = createEventWithMessageEditor({
+    title: "Confirm Task is Complete",
+    messageLabel: "Feedback (optional)",
+    sendText: "Send Confirmation"
+});
+eventEditorComponents[eventTypes.confirmStudentIsExcused] = createEventWithMessageEditor({
+    title: "Confirm Student is Excused",
+    messageLabel: "Comment (optional)",
+    sendText: "Send Confirmation"
+});
+eventEditorComponents[eventTypes.comment] = createEventWithMessageEditor({
+    title: "Comment",
+    sendText: "Add Comment"
+});
+eventEditorComponents[eventTypes.markAndGrade] = markAndGrade;
+

--- a/blocks/core/ff_module/ff_module-task-event/ff_module-task-event.js
+++ b/blocks/core/ff_module/ff_module-task-event/ff_module-task-event.js
@@ -11,15 +11,15 @@ var StampResponseAsSeenTaskEvent = require('./_src/_StampResponseAsSeenTaskEvent
 
 var eventTypes = require('./_src/events').types;
 
-var eventComponents = {
-    [eventTypes.setTask]: SetTaskEvent,
-    [eventTypes.stampResponseAsSeen]: StampResponseAsSeenTaskEvent,
-    [eventTypes.comment]: AddedCommentEvent,
-    [eventTypes.requestResubmission]: RequestResubmissionTaskEvent,
-    [eventTypes.confirmTaskIsComplete]: ConfirmedCompleteTaskEvent,
-    [eventTypes.confirmStudentIsExcused]: ConfirmedStudentExcusedTaskEvent,
-    [eventTypes.markAndGrade]: MarkAndGradeTaskEvent
-};
+var eventComponents = {};
+eventComponents[eventTypes.setTask] = SetTaskEvent;
+eventComponents[eventTypes.stampResponseAsSeen] = StampResponseAsSeenTaskEvent;
+eventComponents[eventTypes.comment] = AddedCommentEvent;
+eventComponents[eventTypes.requestResubmission] = RequestResubmissionTaskEvent;
+eventComponents[eventTypes.confirmTaskIsComplete] = ConfirmedCompleteTaskEvent;
+eventComponents[eventTypes.confirmStudentIsExcused] = ConfirmedStudentExcusedTaskEvent;
+eventComponents[eventTypes.markAndGrade] = MarkAndGradeTaskEvent;
+
 
 
 module.exports = React.createClass({


### PR DESCRIPTION
This is a fix for the IE issue raised here: 

https://trello.com/c/raiZeamC/57-ie10-ie11-and-safari-8-on-osx-yosemite-don-t-render-the-task-details-screen-correctly

@mwilliamson-firefly 
