### PR TITLE
Only set app element on modal to body if body is available

### DIFF
--- a/blocks/core/ff_module/ff_module-task-responses/ff_module-task-responses.js
+++ b/blocks/core/ff_module/ff_module-task-responses/ff_module-task-responses.js
@@ -59,6 +59,8 @@ module.exports = React.createClass({
         if (ref) return ref.portal;
     },
     componentWillMount() {
-        Modal.setAppElement('body');
+        if (typeof document !== "undefined" && document.body) {
+            Modal.setAppElement(document.body);
+        }
     }
 });


### PR DESCRIPTION
This should fix server-side rendering where `document` is unavailable.
