### PR TITLE
Add .idea/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ config/options.local.js
 blocks/**/_icons/optimised_svgs
 npm-debug.log
 .DS_Store
+.idea/


### PR DESCRIPTION
This is used by JetBrains IDEs such as WebStorm.

Should be a harmless change but useful for those who use it, as otherwise their git change list will be polluted.
