### PR TITLE
Update RecipientPicker to allow for autofocus to be turned off

### DIFF
--- a/blocks/core/ff_module/ff_module-recipient-picker/ff_module-recipient-picker-component/_ff_module-recipient-picker-component-renderer.js
+++ b/blocks/core/ff_module/ff_module-recipient-picker/ff_module-recipient-picker-component/_ff_module-recipient-picker-component-renderer.js
@@ -1,17 +1,15 @@
 'use strict';
-var React = require('react'),
-ReactDOM = require('react-dom');
+var ReactDOM = require('react-dom');
 
 var recipientPickerService = require('./_ff_module-recipient-picker-component-mockservice.js')();
-var recipientPicker = require('./ff_module-recipient-picker-component')(recipientPickerService);
+var RecipientPicker = require('./ff_module-recipient-picker-component')(recipientPickerService);
 
 module.exports = function() {
     document.addEventListener('DOMContentLoaded', function(event) {
         var el = document.querySelector('[data-ff-recipient-picker]'); //Use jquery or sim in Firefly for backwards compat
         // var el = document.getElementById('recipient-picker-container');
         if (el) {
-            var picker = ReactDOM.render(React.createElement(recipientPicker), el);
-            // picker.getSelectedRecipients();
+            ReactDOM.render(<RecipientPicker noFocusOnLoad={true} />, el);
         }
     });
 };

--- a/blocks/core/ff_module/ff_module-recipient-picker/ff_module-recipient-picker-component/_ff_module-recipient-picker-component.rt.js
+++ b/blocks/core/ff_module/ff_module-recipient-picker/ff_module-recipient-picker-component/_ff_module-recipient-picker-component.rt.js
@@ -41,7 +41,7 @@ module.exports = function () {
             'className': 'ff_module-recipient-picker-selected-list',
             'onClick': this.stopEventPropagation
         },
-        _.map(this.state.selected, repeatRecipient4.bind(this))
+        this.state.selected && this.state.selected.length > 0 ? _.map(this.state.selected, repeatRecipient4.bind(this)) : null
     ]), React.createElement('input', {
         'className': 'ff_module-recipient-picker__input ff_module-form-input ff_module-form-input--invisible',
         'name': 'recipient-picker-query',

--- a/blocks/core/ff_module/ff_module-recipient-picker/ff_module-recipient-picker-component/ff_module-recipient-picker-component.rt
+++ b/blocks/core/ff_module/ff_module-recipient-picker/ff_module-recipient-picker-component/ff_module-recipient-picker-component.rt
@@ -8,7 +8,7 @@
 
     <div class="ff_module-recipient-picker__main" onClick="{this.resetInput}">
         <ul class="ff_module-recipient-picker-selected-list" onClick="{this.stopEventPropagation}">
-            <li class="ff_module-recipient-picker-selected-list__item" rt-repeat="recipient in this.state.selected" key="sel-{recipient.guid}">
+            <li rt-if="this.state.selected && this.state.selected.length > 0" class="ff_module-recipient-picker-selected-list__item" rt-repeat="recipient in this.state.selected" key="sel-{recipient.guid}">
 
                 <RecipientGroup guid="{recipient.guid}"
                 rt-if="recipient.type === 'groupprofile'"


### PR DESCRIPTION
Turn off the autofocus on first page load - subsequent adding/selecting of items will still re-focus on input field. By default autofocus is still on, to maintain current behaviour.
