### PR TITLE
Revert .link-no-decoration mixin

### DIFF
--- a/blocks/core/ff_util/ff_util-prose/ff_util-prose.less
+++ b/blocks/core/ff_util/ff_util-prose/ff_util-prose.less
@@ -61,21 +61,13 @@
         color: @color;
     }
     .link-no-decoration(@color: @ff_color_control_link) {
-        #ff_mix-util-prose > .link-no-dec-base(@color);
+        text-decoration: none;
+        color: @color;
         &:visited {
            color: darken(@color, 10%);
         }
         &:active, &:hover {
            color: lighten(@color, 10%);
-        }
-    }
-    .link-no-decoration-states(@color: @ff_color_control_link, @color-visited: @ff_color_control_link, @color-hover: @ff_color_control_link) {
-        #ff_mix-util-prose > .link-no-dec-base(@color);
-        &:visited {
-            color: @color-visited;
-        }
-        &:active, &:hover {
-            color: @color-hover;
         }
     }
     .link-quiet {

--- a/blocks/core/ff_util/ff_util-prose/ff_util-prose.less
+++ b/blocks/core/ff_util/ff_util-prose/ff_util-prose.less
@@ -60,7 +60,7 @@
         text-decoration: none;
         color: @color;
     }
-    .link-no-decoration(@color: @ff_color_control_link, @color-visited: null, @color-hover: null) when ((@color-visited = null) and (@color-hover = null)) {
+    .link-no-decoration(@color: @ff_color_control_link) {
         #ff_mix-util-prose > .link-no-dec-base(@color);
         &:visited {
            color: darken(@color, 10%);
@@ -69,7 +69,7 @@
            color: lighten(@color, 10%);
         }
     }
-    .link-no-decoration(@color: @ff_color_control_link, @color-visited: null, @color-hover: null) when not ((@color-visited = null) and (@color-hover = null)) {
+    .link-no-decoration-states(@color: @ff_color_control_link, @color-visited: @ff_color_control_link, @color-hover: @ff_color_control_link) {
         #ff_mix-util-prose > .link-no-dec-base(@color);
         &:visited {
             color: @color-visited;

--- a/blocks/core/ff_util/ff_util-prose/ff_util-prose.less
+++ b/blocks/core/ff_util/ff_util-prose/ff_util-prose.less
@@ -56,10 +56,6 @@
             color: lighten(@ff_color_control_link, 10%);
         }
     }
-    .link-no-dec-base(@color) {
-        text-decoration: none;
-        color: @color;
-    }
     .link-no-decoration(@color: @ff_color_control_link) {
         text-decoration: none;
         color: @color;

--- a/blocks/melody/ff_util/ff_util-prose/ff_util-prose.less
+++ b/blocks/melody/ff_util/ff_util-prose/ff_util-prose.less
@@ -64,7 +64,7 @@
         text-decoration: none;
         color: @color;
     }
-    .link-no-decoration(@color: @ff_color_control_link, @color-visited: null, @color-hover: null) when ((@color-visited = null) and (@color-hover = null)) {
+    .link-no-decoration(@color: @ff_color_control_link) {
         #ff_mix-util-prose > .link-no-dec-base(@color);
         &:visited {
            color: darken(@color, 10%);
@@ -73,7 +73,7 @@
            color: lighten(@color, 10%);
         }
     }
-    .link-no-decoration(@color: @ff_color_control_link, @color-visited: null, @color-hover: null) when not ((@color-visited = null) and (@color-hover = null)) {
+    .link-no-decoration-states(@color: @ff_color_control_link, @color-visited: @ff_color_control_link, @color-hover: @ff_color_control_link) {
         #ff_mix-util-prose > .link-no-dec-base(@color);
         &:visited {
             color: @color-visited;

--- a/blocks/melody/ff_util/ff_util-prose/ff_util-prose.less
+++ b/blocks/melody/ff_util/ff_util-prose/ff_util-prose.less
@@ -60,26 +60,14 @@
             color: lighten(@ff_color_control_link, 10%);
         }
     }
-    .link-no-dec-base(@color) {
+    .link-no-decoration(@color: @ff_color_control_link) {
         text-decoration: none;
         color: @color;
-    }
-    .link-no-decoration(@color: @ff_color_control_link) {
-        #ff_mix-util-prose > .link-no-dec-base(@color);
         &:visited {
            color: darken(@color, 10%);
         }
         &:active, &:hover {
            color: lighten(@color, 10%);
-        }
-    }
-    .link-no-decoration-states(@color: @ff_color_control_link, @color-visited: @ff_color_control_link, @color-hover: @ff_color_control_link) {
-        #ff_mix-util-prose > .link-no-dec-base(@color);
-        &:visited {
-            color: @color-visited;
-        }
-        &:active, &:hover {
-            color: @color-hover;
         }
     }
     .link-disabled(@color:@ff_color_control_link) {


### PR DESCRIPTION
This has been reverted to the previous sate as of PR #125 because we are handling the requirements for ff_container-landing-section differently.
