### PR TITLE
ff_container-dashboard-section: updates to Nautilus

### DIFF
--- a/blocks/nautilus/ff_container/ff_container-dashboard-section/ff_container-dashboard-section.less
+++ b/blocks/nautilus/ff_container/ff_container-dashboard-section/ff_container-dashboard-section.less
@@ -1,6 +1,3 @@
-.ff_container-dashboard-section+.ff_container-dashboard-section {
-    margin-top: 22rem/@ff_base;
-}
 
 .ff_container-dashboard-section {
     
@@ -20,8 +17,9 @@
         font-size: 21rem/@ff_base;
     }
     &__main {
-        #ff_mix-sections > .main();
-        background-color: white;
+       #ff_mix-sections > .main();
+       padding: 0 @ff_size_control_horizontal;
+       background-color: white;
     }
     &__main--no-footer {
         #ff_mix-sections > .main--no-footer()


### PR DESCRIPTION
- Remove the vertical margin on `ff_container-dashboard-section` as it breaks the alignment
- Add in side padding to the main content area of the container (should this be part of core?)
