### PR TITLE
Add invalid event type component in case something goes wrong.

### DIFF
--- a/blocks/core/ff_module/ff_module-task-event/_src/InvalidType.js
+++ b/blocks/core/ff_module/ff_module-task-event/_src/InvalidType.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var React = require('react');
+var eventStates = require('./events').states,
+    taskEventWithOptionalMessage = require('./taskEventWithOptionalMessage').defaultState;
+
+var defaultState = React.createClass({
+    displayName: 'InvalidType',
+    render: taskEventWithOptionalMessage(' - Something went wrong with this response. If this keeps happening, contact our Support Team.')
+});
+
+module.exports = {};
+module.exports[eventStates.default] = defaultState;
+module.exports[eventStates.deleted] = defaultState;
+module.exports[eventStates.edited] = defaultState;

--- a/blocks/core/ff_module/ff_module-task-event/ff_module-task-event.js
+++ b/blocks/core/ff_module/ff_module-task-event/ff_module-task-event.js
@@ -12,7 +12,8 @@ var StampResponseAsSeenTaskEvent = require('./_src/StampResponseAsSeenTaskEvent.
     DeletedResponseTaskEvent = require('./_src/DeletedResponseTaskEvent'),
     AddedFileTaskEvent = require('./_src/AddedFileTaskEvent'),
     SentReminderTaskEvent = require('./_src/SentReminderTaskEvent'),
-    SentFeedbackAndMarks = require('./_src/SentFeedbackAndMarks');
+    SentFeedbackAndMarks = require('./_src/SentFeedbackAndMarks'),
+    InvalidType = require('./_src/InvalidType');
 
 var eventTypes = require('./_src/events').types;
 var eventStates = require('./_src/events').states;
@@ -47,7 +48,12 @@ function getPresentationState(description, state) {
 
 function getComponent(description, state) {
     var presentationState = getPresentationState(description, state);
-    return eventComponents[description.type][presentationState] || eventComponents[description.type][eventStates.default];
+    var componentType = getComponentType(description);
+    return componentType[presentationState] || componentType[eventStates.default];
+}
+
+function getComponentType(description) {
+    return eventComponents[description.type] || InvalidType;
 }
 
 module.exports = React.createClass({


### PR DESCRIPTION
Unlikely to happen in production, but can be fairly common under
development; previously the page would break.
